### PR TITLE
テーブルのエクスポートを実装

### DIFF
--- a/ChallongeSolkoff.Core/SelectSaveFileQuestion.cs
+++ b/ChallongeSolkoff.Core/SelectSaveFileQuestion.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Aldentea.ChallongeSolkoff.Core
+{
+	public class SelectSaveFileQuestion
+	{
+		public Action<string> Callback { get; set; }
+	}
+
+}

--- a/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
+++ b/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
@@ -219,11 +219,11 @@ namespace Aldentea.ChallongeSolkoff.Core
 				{
 					using (var writer = new System.IO.StreamWriter(filename, false, Encoding.UTF8))
 					{
-						var header = "名前,勝,負,ソルコフ,SB,得,失";
+						var header = "名前,勝,負,ソルコフ,SB,得,失,ID";
 						await writer.WriteLineAsync(header);
 						foreach (var participant in Participants)
 						{
-							var line = $"{participant.Name},{participant.Wins},{participant.Loses},{participant.Solkoff},{participant.SbScore},{participant.Plus},{participant.Minus}";
+							var line = $"{participant.Name},{participant.Wins},{participant.Loses},{participant.Solkoff},{participant.SbScore},{participant.Plus},{participant.Minus},{participant.ID}";
 							await writer.WriteLineAsync(line);
 						}
 					}

--- a/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
+++ b/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
@@ -210,6 +210,16 @@ namespace Aldentea.ChallongeSolkoff.Core
 			public IMvxInteraction<SelectSaveFileQuestion> SelectSaveFileInteraction => _selectSaveFileInteraction;
 			readonly MvxInteraction<SelectSaveFileQuestion> _selectSaveFileInteraction;
 
+			void CopyParticipantsList()
+			{
+
+			}
+
+
+			public IMvxInteraction<SelectSaveFileQuestion> CopyToClipboardInteraction => _copyToClipboardInteraction;
+			readonly MvxInteraction<SelectSaveFileQuestion> _copyToClipboardInteraction;
+
+
 		}
 	}
 }

--- a/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
+++ b/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
@@ -72,6 +72,7 @@ namespace Aldentea.ChallongeSolkoff.Core
 			public IMvxCommand RetrieveParticipantsCommand { get; private set; }
 			public IMvxCommand CopyParticipantsListCommand { get; private set; }
 			public IMvxCommand ExportParticipantsCommand { get; private set; }
+			public IMvxCommand ExportMatchesCommand { get; private set; }
 
 			#region *RetrieveParticipantsTaskNotifierプロパティ
 			public MvxNotifyTask RetrieveParticipantsTaskNotifier
@@ -123,6 +124,8 @@ namespace Aldentea.ChallongeSolkoff.Core
 					= new MvxCommand(() => CopyParticipantsList());
 				ExportParticipantsCommand
 					= new MvxCommand(() => ExportParticipants());
+				ExportMatchesCommand
+					= new MvxCommand(() => ExportMatches());
 				//ExportParticipantsCommand
 				//	= new MvxCommand(() => ExportParticipantsTaskNotifier = MvxNotifyTask.Create(
 				//		() => ExportParticipants(), onException: ex => OnException(ex)));
@@ -130,6 +133,7 @@ namespace Aldentea.ChallongeSolkoff.Core
 				_selectSaveFileInteraction = new MvxInteraction<SelectSaveFileQuestion>();
 				_copyToClipboardInteraction = new MvxInteraction<string>();
 			}
+
 			#endregion
 
 
@@ -224,6 +228,36 @@ namespace Aldentea.ChallongeSolkoff.Core
 						foreach (var participant in Participants)
 						{
 							var line = $"{participant.Name},{participant.Wins},{participant.Loses},{participant.Solkoff},{participant.SbScore},{participant.Plus},{participant.Minus},{participant.ID}";
+							await writer.WriteLineAsync(line);
+						}
+					}
+				}
+			}
+
+			private void ExportMatches()
+			{
+				var request = new SelectSaveFileQuestion
+				{
+					Callback = async (filename) =>
+					{
+						await ExportMatchesTo(filename);
+					}
+				};
+				_selectSaveFileInteraction.Raise(request);
+			}
+
+			private async Task ExportMatchesTo(string filename)
+			{
+
+				if (!string.IsNullOrEmpty(filename))
+				{
+					using (var writer = new System.IO.StreamWriter(filename, false, Encoding.UTF8))
+					{
+						var header = "ラウンド,プレイヤー1,プレイヤー2,プレイヤー1スコア,プレイヤー2スコア,プレイヤー1ID,プレイヤー2ID";
+						await writer.WriteLineAsync(header);
+						foreach (var match in Matches)
+						{
+							var line = $"{match.Round},{match.Player1Name},{match.Player2Name},{match.Player1Score},{match.Player2Score},{match.Player1},{match.Player2}";
 							await writer.WriteLineAsync(line);
 						}
 					}

--- a/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
+++ b/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
@@ -207,12 +207,10 @@ namespace Aldentea.ChallongeSolkoff.Core
 						await ExportPartcipantsTo(filename);
 					}
 				};
-
 				_selectSaveFileInteraction.Raise(request);
-			}
 
-			// ※名前だけをクリップボードにコピーするか、成績を含めてファイルに出力するかの2択でよい？
-			// PresentationCore.dllのSystem.Windows.Clipboardを参照？
+				// RaiseしたあとのCallbackでエラーが発生した場合、ここで受け取ることはできない？
+			}
 
 			private async Task ExportPartcipantsTo(string filename)
 			{
@@ -221,9 +219,12 @@ namespace Aldentea.ChallongeSolkoff.Core
 				{
 					using (var writer = new System.IO.StreamWriter(filename, false, Encoding.UTF8))
 					{
+						var header = "名前,勝,負,ソルコフ,SB,得,失";
+						await writer.WriteLineAsync(header);
 						foreach (var participant in Participants)
 						{
-							await writer.WriteLineAsync(participant.Name);
+							var line = $"{participant.Name},{participant.Wins},{participant.Loses},{participant.Solkoff},{participant.SbScore},{participant.Plus},{participant.Minus}";
+							await writer.WriteLineAsync(line);
 						}
 					}
 				}

--- a/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
+++ b/ChallongeSolkoff.Core/ViewModels/MainViewModel.cs
@@ -175,6 +175,40 @@ namespace Aldentea.ChallongeSolkoff.Core
 			#endregion
 
 
+			void ExportParticipants()
+			{
+				var request = new SelectSaveFileQuestion
+				{
+					Callback = (filename) =>
+					{
+						ExportPartcipantsTo(filename);
+					}
+				};
+
+				_selectSaveFileInteraction.Raise(request);
+			}
+
+			// ※名前だけをクリップボードにコピーするか、成績を含めてファイルに出力するかの2択でよい？
+			// PresentationCore.dllのSystem.Windows.Clipboardを参照？
+
+			private void ExportPartcipantsTo(string filename)
+			{
+				
+				if (!string.IsNullOrEmpty(filename))
+				{
+					using (var writer = new System.IO.StreamWriter(filename, false, Encoding.UTF8))
+					{
+						foreach (var participant in Participants)
+						{
+							writer.WriteLine(participant.Name);
+						}
+					}
+				}
+			}
+
+
+			public IMvxInteraction<SelectSaveFileQuestion> SelectSaveFileInteraction => _selectSaveFileInteraction;
+			readonly MvxInteraction<SelectSaveFileQuestion> _selectSaveFileInteraction;
 
 		}
 	}

--- a/ChallongeSolkoff/Views/MainView.xaml
+++ b/ChallongeSolkoff/Views/MainView.xaml
@@ -52,8 +52,9 @@
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="*" />
 					</Grid.RowDefinitions>
-					<StackPanel Grid.Row="0">
+					<StackPanel Grid.Row="0" Orientation="Vertical">
 						<Button Content="参加者名をコピー" Command="{Binding CopyParticipantsListCommand}" />
+						<Button Content="表をエクスポート" Command="{Binding ExportParticipantsCommand}" />
 					</StackPanel>
 				<DataGrid Grid.Row="1" ItemsSource="{Binding Participants}" CanUserAddRows="False" CanUserDeleteRows="False" AutoGenerateColumns="False">
 					<DataGrid.Columns>

--- a/ChallongeSolkoff/Views/MainView.xaml
+++ b/ChallongeSolkoff/Views/MainView.xaml
@@ -15,6 +15,12 @@
 			<RowDefinition Height="Auto" />
 			<RowDefinition />
 		</Grid.RowDefinitions>
+		<Grid.Resources>
+			<Style TargetType="Button">
+				<Setter Property="Padding" Value="20,3" />
+				<Setter Property="Margin" Value="10,3" />
+			</Style>
+		</Grid.Resources>
 		<StackPanel Grid.Row="0">
 			<Expander Header="Challongeユーザ情報">
 				<Grid>
@@ -25,16 +31,16 @@
 					<StackPanel Grid.Row="0" Orientation="Horizontal">
 						<Label Content="ユーザ名" />
 						<TextBox MinWidth="120" InputScope="LogOnName"
-										 Text="{Binding UserName, Mode=TwoWay}" />
+										 Text="{Binding UserName, Mode=TwoWay}" VerticalContentAlignment="Center" />
 					</StackPanel>
 					<StackPanel Grid.Row="1" Orientation="Horizontal">
 						<Label Content="APIキー" />
-						<TextBox MinWidth="240" Text="{Binding ApiKey, Mode=TwoWay}" InputScope="Password" />
+						<TextBox MinWidth="240" Text="{Binding ApiKey, Mode=TwoWay}" InputScope="Password" VerticalContentAlignment="Center" />
 					</StackPanel>
 				</Grid>
 			</Expander>
 			<StackPanel Orientation="Horizontal">
-				<TextBox MinWidth="120" Text="{Binding TournamentID, Mode=TwoWay}" />
+				<TextBox MinWidth="120" Text="{Binding TournamentID, Mode=TwoWay}" VerticalContentAlignment="Center" />
 				<Button  Content="プレイヤー取得" MinWidth="60" Command="{Binding RetrieveParticipantsCommand}" />
 				<Button  Content="マッチ結果取得" MinWidth="60" Command="{Binding RetrieveMatchesCommand}" />
 			</StackPanel>
@@ -52,7 +58,7 @@
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="*" />
 					</Grid.RowDefinitions>
-					<StackPanel Grid.Row="0" Orientation="Vertical">
+					<StackPanel Grid.Row="0" Orientation="Horizontal">
 						<Button Content="参加者名をコピー" Command="{Binding CopyParticipantsListCommand}" />
 						<Button Content="表をエクスポート" Command="{Binding ExportParticipantsCommand}" />
 					</StackPanel>

--- a/ChallongeSolkoff/Views/MainView.xaml
+++ b/ChallongeSolkoff/Views/MainView.xaml
@@ -78,15 +78,24 @@
 				</Grid>
 			</TabItem>
 			<TabItem Header="マッチ結果">
-				<DataGrid ItemsSource="{Binding Matches}" CanUserAddRows="False" CanUserDeleteRows="False" AutoGenerateColumns="False">
-					<DataGrid.Columns>
-						<DataGridTextColumn Header="R" Binding="{Binding Round}" ElementStyle="{StaticResource numberElementStyle}" />
-						<DataGridTextColumn Header="Player1" Binding="{Binding Player1Name}" />
-						<DataGridTextColumn Header="Player2" Binding="{Binding Player2Name}" />
-						<DataGridTextColumn Header="Score1" Binding="{Binding Player1Score}" ElementStyle="{StaticResource numberElementStyle}" />
-						<DataGridTextColumn Header="Score2" Binding="{Binding Player2Score}" ElementStyle="{StaticResource numberElementStyle}" />
-					</DataGrid.Columns>
-				</DataGrid>
+				<Grid>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<StackPanel Grid.Row="0" Orientation="Horizontal">
+						<Button Content="表をエクスポート" Command="{Binding ExportMatchesCommand}" />
+					</StackPanel>
+					<DataGrid Grid.Row="1" ItemsSource="{Binding Matches}" CanUserAddRows="False" CanUserDeleteRows="False" AutoGenerateColumns="False">
+						<DataGrid.Columns>
+							<DataGridTextColumn Header="R" Binding="{Binding Round}" ElementStyle="{StaticResource numberElementStyle}" />
+							<DataGridTextColumn Header="Player1" Binding="{Binding Player1Name}" />
+							<DataGridTextColumn Header="Player2" Binding="{Binding Player2Name}" />
+							<DataGridTextColumn Header="Score1" Binding="{Binding Player1Score}" ElementStyle="{StaticResource numberElementStyle}" />
+							<DataGridTextColumn Header="Score2" Binding="{Binding Player2Score}" ElementStyle="{StaticResource numberElementStyle}" />
+						</DataGrid.Columns>
+					</DataGrid>
+				</Grid>
 			</TabItem>
 		</TabControl>
 

--- a/ChallongeSolkoff/Views/MainView.xaml
+++ b/ChallongeSolkoff/Views/MainView.xaml
@@ -47,7 +47,15 @@
 				</Style>
 			</TabControl.Resources>
 			<TabItem Header="プレイヤー">
-				<DataGrid ItemsSource="{Binding Participants}" CanUserAddRows="True" CanUserDeleteRows="False" AutoGenerateColumns="False">
+				<Grid>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<StackPanel Grid.Row="0">
+						<Button Content="参加者名をコピー" Command="{Binding CopyParticipantsListCommand}" />
+					</StackPanel>
+				<DataGrid Grid.Row="1" ItemsSource="{Binding Participants}" CanUserAddRows="False" CanUserDeleteRows="False" AutoGenerateColumns="False">
 					<DataGrid.Columns>
 						<DataGridTextColumn Header="Name" Binding="{Binding Name}" />
 						<DataGridTextColumn Header="勝" Binding="{Binding Wins}" ElementStyle="{StaticResource numberElementStyle}" />
@@ -60,6 +68,7 @@
 						<DataGridTextColumn Header="ID" Binding="{Binding ID}" />
 					</DataGrid.Columns>
 				</DataGrid>
+				</Grid>
 			</TabItem>
 			<TabItem Header="マッチ結果">
 				<DataGrid ItemsSource="{Binding Matches}" CanUserAddRows="False" CanUserDeleteRows="False" AutoGenerateColumns="False">

--- a/ChallongeSolkoff/Views/MainView.xaml.cs
+++ b/ChallongeSolkoff/Views/MainView.xaml.cs
@@ -29,6 +29,7 @@ namespace Aldentea.ChallongeSolkoff.Views
       // おまじない
       var set = this.CreateBindingSet<MainView, Core.ViewModels.MainViewModel>();
       set.Bind(this).For(view => view.SelectSaveFileInteraction).To(vm => vm.SelectSaveFileInteraction).OneWay();
+      set.Bind(this).For(view => view.CopyToClipboardInteraction).To(vm => vm.CopyToClipboardInteraction).OneWay();
       set.Apply();
     }
 
@@ -70,5 +71,29 @@ namespace Aldentea.ChallongeSolkoff.Views
 			}
 
     }
+
+    public IMvxInteraction<string> CopyToClipboardInteraction
+    {
+      get => _copyToClipboardInteraction;
+      set
+      {
+        if (_copyToClipboardInteraction != null)
+        {
+          _copyToClipboardInteraction.Requested -= OnCopyToClipboardInteractionRequested;
+        }
+        _copyToClipboardInteraction = value;
+        if (value != null)
+          _copyToClipboardInteraction.Requested += OnCopyToClipboardInteractionRequested;
+      }
+    }
+    IMvxInteraction<string> _copyToClipboardInteraction;
+
+
+    void OnCopyToClipboardInteractionRequested(object sender, MvxValueEventArgs<string> eventArgs)
+    {
+      var value = eventArgs.Value;
+      System.Windows.Clipboard.SetText(value);
+    }
+
+    }
   }
-}

--- a/ChallongeSolkoff/Views/MainView.xaml.cs
+++ b/ChallongeSolkoff/Views/MainView.xaml.cs
@@ -11,6 +11,11 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 
+using MvvmCross.Base;
+using MvvmCross.ViewModels;
+using MvvmCross.Binding.BindingContext;
+
+
 namespace Aldentea.ChallongeSolkoff.Views
 {
 	/// <summary>
@@ -20,6 +25,50 @@ namespace Aldentea.ChallongeSolkoff.Views
 		public MainView()
 		{
 			InitializeComponent();
-		}
-	}
+
+      // おまじない
+      var set = this.CreateBindingSet<MainView, Core.ViewModels.MainViewModel>();
+      set.Bind(this).For(view => view.SelectSaveFileInteraction).To(vm => vm.SelectSaveFileInteraction).OneWay();
+      set.Apply();
+    }
+
+    public IMvxInteraction<Core.SelectSaveFileQuestion> SelectSaveFileInteraction
+		{
+      get => _selectSaveFileInteraction;
+      set
+      {
+        if (_selectSaveFileInteraction != null)
+        {
+          _selectSaveFileInteraction.Requested -= OnSelectSaveFileInteractionRequested;
+        }
+        _selectSaveFileInteraction = value;
+        if (value != null)
+          _selectSaveFileInteraction.Requested += OnSelectSaveFileInteractionRequested;
+      }
+    }
+    IMvxInteraction<Core.SelectSaveFileQuestion> _selectSaveFileInteraction;
+
+    void OnSelectSaveFileInteractionRequested(object sender, MvxValueEventArgs<Core.SelectSaveFileQuestion> eventArgs)
+    {
+      var question = eventArgs.Value;
+
+      Microsoft.Win32.SaveFileDialog dialog
+         = new Microsoft.Win32.SaveFileDialog
+         {
+           Filter = "csvファイル(*.csv)|*.csv|すべてのファイル|*",
+           DefaultExt = ".csv",
+           AddExtension = true
+         };
+
+      if (dialog.ShowDialog() == true)
+			{
+        question.Callback(dialog.FileName);
+      }
+      else
+			{
+        question.Callback(string.Empty);
+			}
+
+    }
+  }
 }


### PR DESCRIPTION
- プレイヤーテーブルをcsv形式でエクスポート
- マッチテーブルをcsv形式でエクスポート
- 参加者名のリストをクリップボードにコピー（開始前の参加者確認に使用）